### PR TITLE
Updated osc-dns-config to configure public PTR records + fixed help m…

### DIFF
--- a/provisioning/osc-dns-config
+++ b/provisioning/osc-dns-config
@@ -283,6 +283,7 @@ function createDNSrecord()
 # $1 - IP address for DNS server
 # $2 - IP address for PTR record
 # $3 - DNS domain
+# #4 - scope (i.e.: "PUBLIC" or "PRIVATE")
 #
 
 function prepPTRConfig()
@@ -290,17 +291,18 @@ function prepPTRConfig()
   dns_host=${1}
   ptr_record=${2}
   dns_domain=${3}
+  scope=${4}
 
   in_addr=`getInAddrArpa ${ptr_record}`
 
-  in_addr_arpa_zone="zone \\\"${in_addr}.in-addr.arpa\\\" IN \{\n              type master\;\n              file \\\"static\/${in_addr}.in-addr.arpa.db\\\"\;\n        \}\;\n\n        # IN_ADDR_ARPA_ZONE"
+  in_addr_arpa_zone="zone \\\"${in_addr}.in-addr.arpa\\\" IN \{\n              type master\;\n              file \\\"static\/${in_addr}.in-addr.arpa.db\\\"\;\n        \}\;\n\n        # IN_ADDR_ARPA_ZONE_${scope}"
 
   ${SSH_CMD} root@${dns_host} "
   [ -e "${VAR_NAMED_STATIC_DIR}/${in_addr}.in-addr.arpa.db" ] && exit 0
   cp -f ${VAR_NAMED_STATIC_DIR}/INV_IP_ADDR.in-addr.arpa.db ${VAR_NAMED_STATIC_DIR}/${in_addr}.in-addr.arpa.db
   sed -i \"s/OSE_DNS_DOMAIN/${dns_domain}/g\" ${VAR_NAMED_STATIC_DIR}/${in_addr}.in-addr.arpa.db
   sed -i \"s/INV_IP_ADDR/${in_addr}/g\" ${VAR_NAMED_STATIC_DIR}/${in_addr}.in-addr.arpa.db
-  sed -i \"s/# IN_ADDR_ARPA_ZONE/${in_addr_arpa_zone}/g\" /etc/named.conf
+  sed -i \"s/# IN_ADDR_ARPA_ZONE_${scope}/${in_addr_arpa_zone}/g\" /etc/named.conf
 "
 
   [ $? -ne 0 ] && echo "Failed to set PTR configuration on ${dns_host}" && exit 1
@@ -455,8 +457,8 @@ do
   sleep 1
   setDNSservers ${privateip} ${BASE_DOMAIN} ${dh_private_ip}
 
-  prepPTRConfig ${dh_private_ip} ${privateip} ${BASE_DOMAIN}
-  prepPTRConfig ${dh_private_ip} ${publicip} ${BASE_DOMAIN}
+  prepPTRConfig ${dh_private_ip} ${privateip} ${BASE_DOMAIN} PRIVATE
+  prepPTRConfig ${dh_private_ip} ${publicip} ${BASE_DOMAIN} PUBLIC
   createDNSrecord ${dh_private_ip} ${privateip} ${publicip} "node${i}" "A"
   createDNSrecord ${dh_private_ip} ${privateip} ${publicip} "node${i}.${BASE_DOMAIN}" "PTR"
 
@@ -481,8 +483,8 @@ do
     exit 1
   fi
 
-  prepPTRConfig ${dh_private_ip} ${privateip} ${BASE_DOMAIN}
-  prepPTRConfig ${dh_private_ip} ${publicip} ${BASE_DOMAIN}
+  prepPTRConfig ${dh_private_ip} ${privateip} ${BASE_DOMAIN} PRIVATE
+  prepPTRConfig ${dh_private_ip} ${publicip} ${BASE_DOMAIN} PUBLIC
 
   createDNSrecord ${dh_private_ip} ${privateip} ${publicip} "master${i}" "A"
   createDNSrecord ${dh_private_ip} ${privateip} ${publicip} "master${i}.${BASE_DOMAIN}" "PTR"

--- a/provisioning/osc-dns-config
+++ b/provisioning/osc-dns-config
@@ -62,6 +62,7 @@ function usage()
   echo "                   -n=|--nodes=\"<node1 private ip|node1 public ip>,...,<nodeN private ip|nodeN public ip>\""
   echo "                   -b=|--base_domain=\"<base domain>\""
   echo "                   -d=|--dns_host=\"<DNS host private ip|DHS host public ip>\""
+  echo "                   -w=|--wildcard=\"<wildcard DNS private ip|public ip>\""
   echo ""
   echo "  where:"
   echo "    -m|--master      : comma separated list of master instances, private and public IPs separated by '|'"
@@ -258,10 +259,14 @@ function createDNSrecord()
   "
   elif [ "${dnstype}" = "PTR" ]
   then
-    in_addr=`getInAddrArpa ${privateip}`
-    ptrrecord=`echo ${privateip} | awk -F . '{print $4"."$3}'`
+    private_in_addr=`getInAddrArpa ${privateip}`
+    public_in_addr=`getInAddrArpa ${publicip}`
+    private_ptrrecord=`echo ${privateip} | awk -F . '{print $4"."$3}'`
+    public_ptrrecord=`echo ${publicip} | awk -F . '{print $4"."$3}'`
+
     ${SSH_CMD} root@${dns_host} "
-    echo \"${ptrrecord}  ${ttl}  IN  ${dnstype}   ${hostname}.\" >> ${VAR_NAMED_STATIC_DIR}/${in_addr}.in-addr.arpa.db
+    echo \"${private_ptrrecord}  ${ttl}  IN  ${dnstype}   ${hostname}.\" >> ${VAR_NAMED_STATIC_DIR}/${private_in_addr}.in-addr.arpa.db
+    echo \"${public_ptrrecord}  ${ttl}  IN  ${dnstype}   ${hostname}.\" >> ${VAR_NAMED_STATIC_DIR}/${public_in_addr}.in-addr.arpa.db
   "
   fi
 
@@ -451,6 +456,7 @@ do
   setDNSservers ${privateip} ${BASE_DOMAIN} ${dh_private_ip}
 
   prepPTRConfig ${dh_private_ip} ${privateip} ${BASE_DOMAIN}
+  prepPTRConfig ${dh_private_ip} ${publicip} ${BASE_DOMAIN}
   createDNSrecord ${dh_private_ip} ${privateip} ${publicip} "node${i}" "A"
   createDNSrecord ${dh_private_ip} ${privateip} ${publicip} "node${i}.${BASE_DOMAIN}" "PTR"
 
@@ -476,6 +482,7 @@ do
   fi
 
   prepPTRConfig ${dh_private_ip} ${privateip} ${BASE_DOMAIN}
+  prepPTRConfig ${dh_private_ip} ${publicip} ${BASE_DOMAIN}
 
   createDNSrecord ${dh_private_ip} ${privateip} ${publicip} "master${i}" "A"
   createDNSrecord ${dh_private_ip} ${privateip} ${publicip} "master${i}.${BASE_DOMAIN}" "PTR"

--- a/provisioning/templates/bind/etc/named.conf
+++ b/provisioning/templates/bind/etc/named.conf
@@ -66,7 +66,7 @@ view "private" {
                 file "static/private-OSE_DNS_DOMAIN.db";
         };
 
-	# IN_ADDR_ARPA_ZONE
+	# IN_ADDR_ARPA_ZONE_PRIVATE
 
         // Anything else gets forwarded to the "public" view below
         zone "." {
@@ -82,6 +82,8 @@ view "public" {
                 type master;
                 file "static/public-OSE_DNS_DOMAIN.db";
         };
+
+	# IN_ADDR_ARPA_ZONE_PUBLIC
 
         include "/etc/named.rfc1912.zones";
 


### PR DESCRIPTION
@etsauer added support for public PTR records.

To test, run as usual (i.e.: no changes to usage):

```
>> osc-dns-config -m="<private>|<public>" \
                  -n="<private\>|<public>" \
                  -d="<private>|<public>" \
                  -w="<private>|<public>" \
                  -b="<basedomain>"
```
