### PR TITLE
Added support for separate /var/log partition

### DIFF
--- a/provisioning/openstack/create_base_image
+++ b/provisioning/openstack/create_base_image
@@ -31,6 +31,7 @@ read RHN_USERNAME
 
 echo -n "RHN password: "
 read -s RHN_PASSWORD
+echo
 
 echo -n "RHN pool id: "
 read RHN_POOL_ID
@@ -91,8 +92,8 @@ yum remove -y NetworkManager*
 chkconfig network on
 
 # Self distruct
->/root/.ssh/authorized_keys
->/home/cloud-user/.ssh/authorized_keys
+2>/dev/null >/root/.ssh/authorized_keys
+2>/dev/null >/home/cloud-user/.ssh/authorized_keys
 rm -rf ${SCRIPT_BASE_DIR}/../../
 history -c
 > ~/.bash_history

--- a/provisioning/openstack/create_base_image
+++ b/provisioning/openstack/create_base_image
@@ -58,7 +58,7 @@ sed -i "s/    postrotate/ \
 
 subscription-manager register --username=$RHN_USERNAME --password=$RHN_PASSWORD
 subscription-manager attach --pool=$RHN_POOL_ID
-subscription-manager repos --disable="*"
+subscription-manager repos --disable='*'
 subscription-manager repos \
 --enable="rhel-7-server-rpms" \
 --enable="rhel-7-server-extras-rpms" \

--- a/provisioning/openstack/create_base_image
+++ b/provisioning/openstack/create_base_image
@@ -30,6 +30,12 @@ sed -i 's/disable_root: 1/disable_root: 0/' /etc/cloud/cloud.cfg
 sed -i 's/datasource_list/# datasource_list/' /etc/cloud/cloud.cfg
 echo "datasource_list: [ None ]" >> /etc/cloud/cloud.cfg
 
+# Setup a more suitable log rotate pattern for "standard" syslog files
+sed -i "s/    postrotate/ \
+   rotate 10\n \
+   maxsize 500M\n \
+   delaycompress\n \
+   postrotate/" /etc/logrotate.d/syslog
 
 subscription-manager register --username=$RHN_USERNAME --password=$RHN_PASSWORD
 subscription-manager attach --pool=$RHN_POOL_ID

--- a/provisioning/openstack/create_base_image
+++ b/provisioning/openstack/create_base_image
@@ -27,6 +27,9 @@ fi
 
 # Enable root access
 sed -i 's/disable_root: 1/disable_root: 0/' /etc/cloud/cloud.cfg
+sed -i 's/datasource_list/# datasource_list/' /etc/cloud/cloud.cfg
+echo "datasource_list: [ None ]" >> /etc/cloud/cloud.cfg
+
 
 subscription-manager register --username=$RHN_USERNAME --password=$RHN_PASSWORD
 subscription-manager attach --pool=$RHN_POOL_ID
@@ -36,17 +39,38 @@ subscription-manager repos \
 --enable="rhel-7-server-extras-rpms" \
 --enable="rhel-7-server-optional-rpms" \
 --enable="rhel-7-server-ose-3.0-rpms"
-yum remove -y NetworkManager*
-yum install -y wget git net-tools bind-utils iptables-services bridge-utils
+yum clean all
+yum install -y wget git net-tools bind-utils iptables-services bridge-utils rsync
 yum update -y
+
+# Create the /var/log partition
+(echo n; echo p; echo; echo; echo t; echo 4; echo 8e; echo w;) | fdisk /dev/vda
+partprobe
+pvcreate /dev/vda4 
+vgcreate vg_var /dev/vda4
+lvcreate -l 100%VG -n lv_log vg_var
+mkfs.xfs /dev/vg_var/lv_log 
+mkdir /mnt/log
+mount /dev/mapper/vg_var-lv_log /mnt/log
+rsync -a -A -X /var/log/ /mnt/log
+umount /mnt/log
+echo "/dev/mapper/vg_var-lv_log /var/log xfs defaults 0 0" >> /etc/fstab 
 
 # Copy some files
 SCRIPT_BASE_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 cp -r ${SCRIPT_BASE_DIR}/../../ose3eval/files/* /
 
+# Remove NetworkManager + 
+# Ensure networking is enabled
+# - have to use 'chkconfig' and 'service' for this
+yum remove -y NetworkManager*
+chkconfig network on
+
 # Self distruct
 >/root/.ssh/authorized_keys
 >/home/cloud-user/.ssh/authorized_keys
+>/home/fedora/.ssh/authorized_keys
 rm -rf ${SCRIPT_BASE_DIR}/../../
 history -c
+> ~/.bash_history
 shutdown -h now

--- a/provisioning/openstack/create_base_image
+++ b/provisioning/openstack/create_base_image
@@ -64,6 +64,16 @@ subscription-manager repos \
 --enable="rhel-7-server-extras-rpms" \
 --enable="rhel-7-server-optional-rpms" \
 --enable="rhel-7-server-ose-3.0-rpms"
+
+enabled_repos=`yum repolist`
+if [ -z "`echo ${enabled_repos} | grep \" rhel-7-server-rpms\/\"`" ] || \
+   [ -z "`echo ${enabled_repos} | grep \" rhel-7-server-extras-rpms\/\"`" ] || \
+   [ -z "`echo ${enabled_repos} | grep \" rhel-7-server-optional-rpms\/\"`" ] || \
+   [ -z "`echo ${enabled_repos} | grep \" rhel-7-server-ose-3.0-rpms\/\"`" ]; then
+  echo "Failed to enable required repos!"
+  exit 1
+fi
+
 yum clean all
 yum install -y wget git net-tools bind-utils iptables-services bridge-utils rsync
 yum update -y

--- a/provisioning/openstack/create_base_image
+++ b/provisioning/openstack/create_base_image
@@ -68,7 +68,7 @@ cp -r ${SCRIPT_BASE_DIR}/../../ose3eval/files/* /
 
 # Remove NetworkManager + 
 # Ensure networking is enabled
-# - have to use 'chkconfig' and 'service' for this
+# - have to use 'chkconfig' for this
 yum remove -y NetworkManager*
 chkconfig network on
 

--- a/provisioning/openstack/create_base_image
+++ b/provisioning/openstack/create_base_image
@@ -8,22 +8,40 @@
 # tar cf - ./ose-utils | ssh cloud-user@<instsance ip> tar xf -
 # ssh cloud-user@<instance-ip>
 # [cloud-user@ip]$ sudo -i
-# [root@ip]# export RHN_USERNAME=<>
-# [root@ip]# export RHN_PASSWORD=<>
-# [root@ip]# export RHN_POOL_ID=<>
 # [root@ip]# bash /home/cloud-user/ose-utils/provisioning/openstack/create_base_image
 
 # Shutdown instance and take snapshot
 # DONE
 
+echo "This tool will run RHN subscription-manager."
+echo "Please provide your RHN username/password, and a subscription pool id, when prompted."
+echo "Please exit now (ctrl+c) if you don't have this information available."
+
+i=9
+while [ $i -gt 0 ]
+do
+	echo -ne "  ${i} ...\033[0K\r"
+	i=$((i-1))
+	sleep 1
+done
+
+echo
+echo -n "RHN Username: "
+read RHN_USERNAME
+
+echo -n "RHN password: "
+read -s RHN_PASSWORD
+
+echo -n "RHN pool id: "
+read RHN_POOL_ID
+
 # Check for prereqs
 if [ -z $RHN_USERNAME ] || [ -z $RHN_PASSWORD ] || [ -z $RHN_POOL_ID ]; then
-  echo "Missing some environment info. Please make sure to export the following to your env:"
-  echo " - RHN_USERNAME"
-  echo " - RHN_PASSWORD"
-  echo " - RHN_POOL_ID"
+  echo "Missing some RHN info. Please retry..."
   exit 1
 fi
+
+echo "Thank you! Proceeding..."
 
 # Enable root access
 sed -i 's/disable_root: 1/disable_root: 0/' /etc/cloud/cloud.cfg
@@ -75,7 +93,6 @@ chkconfig network on
 # Self distruct
 >/root/.ssh/authorized_keys
 >/home/cloud-user/.ssh/authorized_keys
->/home/fedora/.ssh/authorized_keys
 rm -rf ${SCRIPT_BASE_DIR}/../../
 history -c
 > ~/.bash_history


### PR DESCRIPTION
@etsauer Changes to create_base_image to support a separate /var/log partition

Please use the "ose3_minimal" image to test with - i.e.: launch a new instance of the "ose3_minimal", then follow the normal steps to run create_base_image. Note that the "ose3_minimal" image uses the user "fedora" rather than "cloud-user" by default.
