### PR TITLE
Secure registry and create route for external access to registry on Install.

### DIFF
--- a/provisioning/osc-install
+++ b/provisioning/osc-install
@@ -297,7 +297,7 @@ do_post(){
 
   # Remove --insecure-registry flag set by ansible (https://github.com/openshift/openshift-ansible/issues/497)
   for node in ${NODE_HOSTNAMES//,/ }; do
-    $SSH_CMD $node 'sed -i "s/--insecure-registry 172.30.0.0\/16//" /etc/sysconfig/docker && systemctl restart docker'
+    $SSH_CMD $node 'sed "s/--insecure-registry=172.30.0.0\/16//" /etc/sysconfig/docker && systemctl restart docker'
   done
 }
 

--- a/provisioning/osc-install
+++ b/provisioning/osc-install
@@ -143,7 +143,7 @@ setup_training_repo() {
 setup_storage() {
   # Install and configure docker
   yum -y install docker &>/dev/null || error_out "Failed to install package docker"
-  sed -i "s/OPTIONS='--selinux-enabled'/OPTIONS='--selinux-enabled --insecure-registry 172.30.0.0\/16'/" /etc/sysconfig/docker
+#  sed -i "s/OPTIONS='--selinux-enabled'/OPTIONS='--selinux-enabled --insecure-registry 172.30.0.0\/16'/" /etc/sysconfig/docker
 
   vgdisplay vg-docker &>/dev/null
   vgd=$?
@@ -279,23 +279,7 @@ do_post(){
   --images='registry.access.redhat.com/openshift3/ose-${component}:${version}' \
   --service-account=router
 
-  # Create registry
-  mkdir -p /mnt/registry
-
-  echo '{"kind":"ServiceAccount","apiVersion":"v1","metadata":{"name":"registry"}}' | oc create -f -
-  oc get scc privileged -o yaml > priv.yaml
-  if [ $(grep -c 'system:serviceaccount:default:registry' priv.yaml) -eq 0 ]; then
-    echo '- system:serviceaccount:default:registry' >> priv.yaml
-    oc replace scc privileged -f priv.yaml
-  fi
-
-  oadm registry --service-account=registry \
-  --config=/etc/openshift/master/admin.kubeconfig \
-  --credentials=/etc/openshift/master/openshift-registry.kubeconfig \
-  --images='registry.access.redhat.com/openshift3/ose-${component}:${version}' \
-  --selector='region=infra' \
-  --mount-host=/mnt/registry \
-
+  do_create_registry
   ### Workarounds for current issues
 
   # Apply node labels after install (https://bugzilla.redhat.com/show_bug.cgi?id=1235953)
@@ -310,6 +294,71 @@ do_post(){
     fi
     oc label node/${node} region=$region zone=$zone
   done
+}
+
+do_create_registry() {
+  CA=/etc/openshift/master
+
+  # First, a bit of cleanup so we can re-run and update things
+  for resource in se dc pod; do
+    resource_names=$(oc get $resource | awk '/registry/ {print $1}')
+    for name in ${resource_names/'\n'/ }; do
+      oc delete $resource $name
+    done
+  done
+
+  # Create registry
+  mkdir -p /mnt/registry
+
+  echo '{"kind":"ServiceAccount","apiVersion":"v1","metadata":{"name":"registry"}}' | oc create -f -
+  oc get scc privileged -o yaml > priv.yaml
+  if [ $(grep -c 'system:serviceaccount:default:registry' priv.yaml) -eq 0 ]; then
+    echo '- system:serviceaccount:default:registry' >> priv.yaml
+    oc replace scc privileged -f priv.yaml
+  fi
+
+  created_resources=$(oadm registry --service-account=registry \
+  --config=/etc/openshift/master/admin.kubeconfig \
+  --credentials=/etc/openshift/master/openshift-registry.kubeconfig \
+  --images='registry.access.redhat.com/openshift3/ose-${component}:${version}' \
+  --selector='region=infra' \
+  --mount-host=/mnt/registry)
+
+  service_name=$(echo "${created_resources}" | awk -F'/' '/services/ {print $2}')
+  dc_name=$(echo "${created_resources}" | awk -F'/' '/deploymentconfigs/ {print $2}')
+  service_ip=$(oc get service $service_name | awk '/registry/ {print $4}')
+
+  # Secure the Registry
+  oadm ca create-server-cert --signer-cert=$CA/ca.crt \
+    --signer-key=$CA/ca.key \
+    --signer-serial=$CA/ca.serial.txt  \
+    --hostnames="registry.apps.${OPENSHIFT_BASE_DOMAIN},docker-registry.default.svc.cluster.local,${service_ip}"\
+    --cert=$CA/registry.crt --key=$CA/registry.key
+
+  oc secrets new registry-secret $CA/registry.crt $CA/registry.key
+
+  oc secrets add serviceaccounts/registry secrets/registry-secret
+
+  oc volume dc/$dc_name --add --type=secret --secret-name=registry-secret -m /etc/secrets
+
+  oc env dc/$dc_name REGISTRY_HTTP_TLS_CERTIFICATE=/etc/secrets/registry.crt REGISTRY_HTTP_TLS_KEY=/etc/secrets/registry.key
+
+  # Trust certs from all nodes
+  certs_dirs="/etc/docker/certs.d/$service_ip:5000 /etc/docker/certs.d/docker-registry.default.svc.cluster.local:5000"
+  for node in ${NODE_HOSTNAMES//,/ }; do
+    for dir in $certs_dirs; do
+      $SSH_CMD $node "mkdir -p $dir"
+      $SCP_CMD $CA/ca.crt $node:$dir
+      $SSH_CMD $node "systemctl daemon-reload && systemctl restart docker"
+    done
+  done
+
+  # Create Route for External Access
+  route_resource=$(cat ${SCRIPT_BASE_DIR}/templates/registry-route.json)
+  route_resource=$(echo "$route_resource" | sed "s/SERVICE_NAME/$service_name/g")
+  route_resource=$(echo "$route_resource" | sed "s/HOSTNAME/registry.apps.${OPENSHIFT_BASE_DOMAIN}/g")
+
+  echo "$route_resource" | oc create -f -
 }
 
 # Process input

--- a/provisioning/osc-install
+++ b/provisioning/osc-install
@@ -294,6 +294,11 @@ do_post(){
     fi
     oc label node/${node} region=$region zone=$zone
   done
+
+  # Remove --insecure-registry flag set by ansible (https://github.com/openshift/openshift-ansible/issues/497)
+  for node in ${NODE_HOSTNAMES//,/ }; do
+    $SSH_CMD $node 'sed -i "s/--insecure-registry 172.30.0.0\/16//" /etc/sysconfig/docker && systemctl restart docker'
+  done
 }
 
 do_create_registry() {

--- a/provisioning/osc-install
+++ b/provisioning/osc-install
@@ -297,7 +297,7 @@ do_post(){
 
   # Remove --insecure-registry flag set by ansible (https://github.com/openshift/openshift-ansible/issues/497)
   for node in ${NODE_HOSTNAMES//,/ }; do
-    $SSH_CMD $node 'sed "s/--insecure-registry=172.30.0.0\/16//" /etc/sysconfig/docker && systemctl restart docker'
+    $SSH_CMD $node 'sed -i "s/--insecure-registry=172.30.0.0\/16//" /etc/sysconfig/docker && systemctl restart docker'
   done
 }
 

--- a/provisioning/templates/registry-route.json
+++ b/provisioning/templates/registry-route.json
@@ -1,0 +1,22 @@
+{
+  "kind": "Route",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "registry",
+    "namespace": "default",
+    "labels": {
+      "SERVICE_NAME": "default"
+    }
+  },
+  "spec": {
+    "host": "HOSTNAME",
+    "to": {
+      "kind": "Service",
+      "name": "SERVICE_NAME"
+    },
+    "tls": {
+      "termination": "passthrough"
+    }
+  },
+  "status": {}
+}


### PR DESCRIPTION
Steps to test:
1. Provision Environment:

``` bash
./provisioning/osc-provision --num-nodes=2 --key=<key>
```
1. Internal test

``` bash
[root@master ~]# oadm new-project internal-test
[root@master ~]# oc new-app --template=eap6-basic-sti -n internal-test
[root@master ~]# oc start-build eap-app -n internal-test
[root@master ~]# oc build-logs eap-app-1 -n internal-test
... wait for build to run and validate that the image is successfully pushed to the registry service ip....
```
1. External Test
   @sabre1041 please provide external test instructions
