### PR TITLE
Added jq package and EPEL to cicd install

### DIFF
--- a/provisioning/cicd-install
+++ b/provisioning/cicd-install
@@ -71,8 +71,7 @@ function check_prereqs() {
 function install_prereqs() {
 	
 	#EPEL
-	wget -O ${CICD_SETUP_DIR}/epel-release-7-5.noarch.rpm http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
-	rpm -Uvh ${CICD_SETUP_DIR}/epel-release-7-5.noarch.rpm
+	yum -y install http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
 	
 	yum install -y wget git vim jq &>/dev/null || error_out "Failed to install prerequisite software"
 }

--- a/provisioning/cicd-install
+++ b/provisioning/cicd-install
@@ -69,7 +69,12 @@ function check_prereqs() {
 #
 
 function install_prereqs() {
-	yum install -y wget git vim &>/dev/null || error_out "Failed to install prerequisite software"
+	
+	#EPEL
+	wget -O ${CICD_SETUP_DIR}/epel-release-7-5.noarch.rpm http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
+	rpm -Uvh ${CICD_SETUP_DIR}/epel-release-7-5.noarch.rpm
+	
+	yum install -y wget git vim jq &>/dev/null || error_out "Failed to install prerequisite software"
 }
 
 #


### PR DESCRIPTION
Added jq package from EPEL to cicd installation. 

jq is a json parsing tool for bash and is being used by scripts executed by Jenkins to interrupt responses from OSE 
