### PR TITLE
Added jq package and EPEL to prerequisite software list for cicd install

### DIFF
--- a/provisioning/cicd-install
+++ b/provisioning/cicd-install
@@ -69,7 +69,9 @@ function check_prereqs() {
 #
 
 function install_prereqs() {
-	yum install -y wget git vim &>/dev/null || error_out "Failed to install prerequisite software" 2
+	
+	# EPEL and software packages	
+	yum install -y install http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm wget git vim jq &>/dev/null || error_out "Failed to install prerequisite software" 2
 }
 
 #


### PR DESCRIPTION
Added jq package from EPEL to cicd installation.

jq is a json parsing tool for bash and is being used by scripts executed by Jenkins to interrupt responses from OSE
